### PR TITLE
Updated reveal default command to force usage of bash shell.

### DIFF
--- a/abm/abm.js
+++ b/abm/abm.js
@@ -535,7 +535,7 @@ function reveal_env_build(env) {
   switch (process.platform) {
     case 'win32': cmd = `Explorer /select,${stat.filename}`; break;
     case 'darwin': cmd = `open -R ${stat.filename}`; break;
-    default: cmd = '`which xdg-open open other-open | grep -v found | head -n1` .';
+    default: cmd = 'bash -c "`which xdg-open open other-open | grep -v found | head -n1` ."';
   }
   command_with_ping(aterm, `cd "${escpath}"`);
   command_with_ping(aterm, cmd);

--- a/abm/abm.js
+++ b/abm/abm.js
@@ -535,7 +535,7 @@ function reveal_env_build(env) {
   switch (process.platform) {
     case 'win32': cmd = `Explorer /select,${stat.filename}`; break;
     case 'darwin': cmd = `open -R ${stat.filename}`; break;
-    default: cmd = 'bash -c "`which xdg-open open other-open | grep -v found | head -n1` ."';
+    default: cmd = '`bash -c "`which xdg-open open other-open | grep -v found | head -n1` ."';
   }
   command_with_ping(aterm, `cd "${escpath}"`);
   command_with_ping(aterm, cmd);


### PR DESCRIPTION
Fish shell doesn't work with this command.

A better implementation would search for bash or sh and use the appropriate command.

This is a temporary fix for Issue #84 